### PR TITLE
Autovala defines carry through

### DIFF
--- a/src/autovalaLib/elementValaBinary.vala
+++ b/src/autovalaLib/elementValaBinary.vala
@@ -1415,6 +1415,7 @@ namespace AutoVala {
 						dataStream.put_string("if (%s)\n".printf(element.name));
 						dataStream.put_string("\tset (COMPILE_OPTIONS ${COMPILE_OPTIONS} -D %s)\n".printf(element.name));
                         dataStream.put_string("\tset (CMAKE_C_FLAGS \"${CMAKE_C_FLAGS} -D%s \" )\n".printf(element.name));
+                        dataStream.put_string("\tset (CMAKE_CXX_FLAGS \"${CMAKE_CXX_FLAGS} -D%s \" )\n".printf(element.name));
 						dataStream.put_string("endif ()\n");
 					}
 				}

--- a/src/autovalaLib/elementValaBinary.vala
+++ b/src/autovalaLib/elementValaBinary.vala
@@ -1414,6 +1414,7 @@ namespace AutoVala {
 						addDefines=true;
 						dataStream.put_string("if (%s)\n".printf(element.name));
 						dataStream.put_string("\tset (COMPILE_OPTIONS ${COMPILE_OPTIONS} -D %s)\n".printf(element.name));
+                        dataStream.put_string("\tset (CMAKE_C_FLAGS \"${CMAKE_C_FLAGS} -D%s \" )\n".printf(element.name));
 						dataStream.put_string("endif ()\n");
 					}
 				}


### PR DESCRIPTION
These two lines add a bit to the generated CMakeLists.txt file so that the autovala defines as marked in .avprj file will define the relevant flag in C and CXX as well as in Vala.  This is useful for projects that make moderate to heavy use of C code directly, and requires less time from the user to edit the CMakeLists.txt manually. 