### PR TITLE
Fix compile error when targeted WIN32

### DIFF
--- a/data/cmake/ValaPrecompile.cmake
+++ b/data/cmake/ValaPrecompile.cmake
@@ -200,7 +200,7 @@ macro(vala_precompile output target_name)
 	
     set(os_defines "")
     if(WIN32)
-        list(APPEND os_defines "-D \"G_OS_WIN32\"")
+        list(APPEND os_defines "-D" "\"G_OS_WIN32\"")
     endif(WIN32)
 
     # Workaround for a bug that would make valac run twice. This file is written


### PR DESCRIPTION
When used MinGW as a c compiler, had occurred error of valac due to the invalid option ``-D\ "G_OS_WIN32"`` which was generated by cmake. (escaped the space)
The option should be ``-D "G_OS_WIN32"``.
